### PR TITLE
test: add tests for functions about channelmap

### DIFF
--- a/src/__tests__/channel.spec.ts
+++ b/src/__tests__/channel.spec.ts
@@ -1,15 +1,13 @@
-import { getApiChannelMap } from '../channel'
+import { getApiChannelMap, haveSameStructure } from '../channel'
+import * as uuid from '../utils/uuid'
 
 import type { IpcMainInvokeEvent } from 'electron'
 
 describe('Generate api channel map', () => {
-  vi.mock('crypto', () => {
-    return {
-      randomUUID: vi.fn().mockReturnValue('uuid'),
-    }
-  })
+  const dummyUUID = '1234-abcd-1234-abcd-1234'
+  const uuidSpy = vi.spyOn(uuid, 'genUUID').mockReturnValue(dummyUUID)
 
-  it('success', () => {
+  it('generate vaild structure', () => {
     const apiHandlers = {
       invoke: {
         fn1: (e: IpcMainInvokeEvent) => console.log(e),
@@ -26,16 +24,123 @@ describe('Generate api channel map', () => {
     const result = getApiChannelMap(apiHandlers)
     assert.deepEqual(result, {
       invoke: {
-        fn1: 'uuid',
-        fn2: 'uuid',
+        fn1: dummyUUID,
+        fn2: dummyUUID,
         name1: {
-          fn1: 'uuid',
-          fn2: 'uuid',
+          fn1: dummyUUID,
+          fn2: dummyUUID,
         },
       },
       on: {
-        fn1: 'uuid',
+        fn1: dummyUUID,
       },
     })
+  })
+
+  it('same chanelmap are retured when multiple called', () => {
+    uuidSpy.mockRestore()
+    const apiHandlers = {
+      invoke: {
+        fn1: (e: IpcMainInvokeEvent) => console.log(e),
+        fn2: (e: IpcMainInvokeEvent) => console.log(e),
+        name1: {
+          fn1: () => console.log(),
+          fn2: (e: IpcMainInvokeEvent) => console.log(e),
+        },
+      },
+      on: {
+        fn1: () => console.log('sss'),
+        name2: {
+          fn1: () => console.log(),
+          fn2: (e: IpcMainInvokeEvent) => console.log(e),
+        },
+      },
+    } as const
+    const result1 = getApiChannelMap(apiHandlers)
+    const result2 = getApiChannelMap(apiHandlers)
+    assert.deepEqual(result1, result2)
+  })
+})
+
+describe('haveSameStructure', () => {
+  it('success', () => {
+    const apiHandlers = {
+      invoke: {
+        fn1: (e: IpcMainInvokeEvent) => console.log(e),
+        fn2: (e: IpcMainInvokeEvent) => console.log(e),
+        name1: {
+          fn1: () => console.log(),
+          fn2: (e: IpcMainInvokeEvent) => console.log(e),
+        },
+      },
+      on: {
+        fn1: () => console.log('sss'),
+        name2: {
+          fn1: () => console.log(),
+          fn2: (e: IpcMainInvokeEvent) => console.log(e),
+        },
+      },
+    } as const
+
+    const channelMap = {
+      invoke: {
+        fn1: 'uuid-fn1',
+        fn2: 'uuid-fn2',
+        name1: {
+          fn1: 'uuid-name1-fn1',
+          fn2: 'uuid-name1-fn2',
+        },
+      },
+      on: {
+        fn1: 'uuid-fn1',
+        name2: {
+          fn1: 'uuid-name2-fn1',
+          fn2: 'uuid-name2-fn2',
+        },
+      },
+    }
+    expect(haveSameStructure(apiHandlers, channelMap)).toBeTruthy()
+    console.log()
+  })
+
+  it('fail', () => {
+    const apiHandlers = {
+      invoke: {
+        fn1: (e: IpcMainInvokeEvent) => console.log(e),
+        fn2: (e: IpcMainInvokeEvent) => console.log(e),
+        name1: {
+          fn1: () => console.log(),
+          fn2: (e: IpcMainInvokeEvent) => console.log(e),
+        },
+      },
+      on: {
+        fn1: () => console.log('sss'),
+        name2: {
+          fn1: () => console.log(),
+          fn2: (e: IpcMainInvokeEvent) => console.log(e),
+        },
+      },
+    } as const
+
+    const channelMap = {
+      invoke: {
+        fn1: 'uuid-fn1',
+        fn2: 'uuid-fn2',
+        name1: {
+          fn1: 'uuid-name1-fn1',
+          // fn2: 'uuid-name1-fn2', // unmatch
+          fn3: 'uuid-name1-fn3', // unmatch
+        },
+      },
+      on: {
+        fn1: 'uuid-fn1',
+        name2: {
+          fn1: 'uuid-name2-fn1',
+          // fn2: 'uuid-name2-fn2', // unmatch
+        },
+      },
+    }
+    // @ts-ignore
+    expect(haveSameStructure(apiHandlers, channelMap)).toBeFalsy()
   })
 })

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto'
+import { genUUID } from './utils/uuid'
 
 import type { IpcMainInvokeEvent } from 'electron'
 
@@ -44,11 +44,14 @@ export type ApiChannelMapGenerator<T extends IpcBridgeApiImplementation> = {
 
 let channelMap = undefined
 
-function haveSameStructure(obj1, obj2) {
+export function haveSameStructure<T extends IpcBridgeApiImplementation>(
+  obj1: T,
+  obj2: ApiChannelMapGenerator<T>
+) {
   if (!obj1 || !obj2) {
     return false
   }
-  if (typeof obj1 !== 'object' && typeof obj2 !== 'object') {
+  if (typeof obj1 === 'function' && typeof obj2 === 'string') {
     return true
   }
   if (typeof obj1 !== 'object' || typeof obj2 !== 'object') {
@@ -79,7 +82,7 @@ function getApiChannelMap(apiHandlers: IpcBridgeApiImplementation) {
       if (typeof apiHandler[key] === 'object') {
         channelMap[key] = _getApiChannelMap(apiHandler[key])
       } else {
-        channelMap[key] = randomUUID()
+        channelMap[key] = genUUID()
       }
     })
     return channelMap

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,3 @@
+import { randomUUID } from 'node:crypto'
+
+export const genUUID = () => randomUUID()


### PR DESCRIPTION
Test whether the same channelMap is returned when called multiple times.
Since randomUUID cannot be used with spyOn, it is extracted as a
separate test file.
