### PR TITLE
feat: change the return value for ipc with "on" to be Promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ There are following reasends.
 
 1. When implementing IPC using contextBridge, we want to use it in a type-safe.
 
-<img width="824" alt="image" src="https://github.com/user-attachments/assets/cbe58812-bda6-4294-bb28-911f549c6a3e">
+   <img width="824" alt="image" src="https://github.com/user-attachments/assets/cbe58812-bda6-4294-bb28-911f549c6a3e">
 
 1. We want to be freed from channel management.
 

--- a/playground/src/main/api/index.ts
+++ b/playground/src/main/api/index.ts
@@ -10,11 +10,11 @@ export const api = {
   invoke: {
     ping: () => console.log('pong'),
     culc: {
-      add: async (_event: IpcMainInvokeEvent, arg0: number, arg1: number) => {
+      add: (_event: IpcMainInvokeEvent, arg0: number, arg1: number) => {
         console.log(`arg0: ${arg0}, arg1:${arg1}`)
         return arg0 + arg1
       },
-      minus: async (_event: IpcMainInvokeEvent, arg0: number, arg1: number) => {
+      minus: (_event: IpcMainInvokeEvent, arg0: number, arg1: number) => {
         console.log(`arg0: ${arg0}, arg1: ${arg1}`)
         return arg0 - arg1
       }

--- a/src/__tests__/types.spec.ts
+++ b/src/__tests__/types.spec.ts
@@ -1,14 +1,18 @@
 import type { BrowserWindow, IpcMainInvokeEvent, IpcRendererEvent } from 'electron'
-import type { RemoveEventArg, IpcBridgeApiTypeGenerator, IpcBridgeApiInvoker } from '../preload'
+import type {
+  IpcBridgeApiFunction,
+  IpcBridgeApiTypeGenerator,
+  IpcBridgeApiInvoker,
+} from '../preload'
 import type { ApiChannelMapGenerator } from '../channel'
 import type { IpcBridgeApiEmitterTypeGenerator } from '../main'
 
 describe('Type check', () => {
-  it('RemoveEventArg', () => {
+  it('IpcBridgeApiFunction', () => {
     const _fn = (e: IpcMainInvokeEvent, arg1: string) => arg1
-    type ExpectedApiType = (arg1: string) => string
+    type ExpectedApiType = (arg1: string) => Promise<string>
 
-    expectTypeOf<ExpectedApiType>().toEqualTypeOf<RemoveEventArg<typeof _fn>>()
+    expectTypeOf<ExpectedApiType>().toEqualTypeOf<IpcBridgeApiFunction<typeof _fn>>()
   })
 
   it('IpcBridgeApiInvoker', () => {
@@ -23,11 +27,11 @@ describe('Type check', () => {
 
     type IpcBridgeApi = IpcBridgeApiInvoker<typeof _apiHandlers>
     type ExpectedType = {
-      fn1: () => void
-      fn2: () => string
+      fn1: () => Promise<void>
+      fn2: () => Promise<string>
       name1: {
-        fn1: (arg1: string) => string
-        fn2: () => void
+        fn1: (arg1: string) => Promise<string>
+        fn2: () => Promise<void>
       }
     }
 
@@ -160,11 +164,11 @@ describe('Type check', () => {
       type TestTarget = IpcBridgeApiTypeGenerator<typeof _apiHandlers>
       type ExpectedType = {
         invoke: {
-          fn1: () => void
-          fn2: () => string
+          fn1: () => Promise<void>
+          fn2: () => Promise<string>
           name1: {
-            fn1: (arg1: number, arg2: number) => number
-            fn2: (arg1: string) => string
+            fn1: (arg1: number, arg2: number) => Promise<number>
+            fn2: (arg1: string) => Promise<string>
           }
         }
         on: {
@@ -193,11 +197,11 @@ describe('Type check', () => {
       type TestTarget = IpcBridgeApiTypeGenerator<typeof _apiHandlers>
       type ExpectedType = {
         invoke: {
-          fn1: () => void
-          fn2: () => string
+          fn1: () => Promise<void>
+          fn2: () => Promise<string>
           name1: {
-            fn1: (arg1: number, arg2: number) => number
-            fn2: (arg1: string) => string
+            fn1: (arg1: number, arg2: number) => Promise<number>
+            fn2: (arg1: string) => Promise<string>
           }
         }
       }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -10,21 +10,22 @@ type ApiChannelMap = {
   [key: string]: string | ApiChannelMap
 }
 
-export type RemoveEventArg<F> = F extends (
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Awaitable<T> = T extends Promise<any> ? T : Promise<T>
+
+export type IpcBridgeApiFunction<F> = F extends (
   event: IpcMainInvokeEvent,
   ...args: infer Args
 ) => infer R
-  ? (...args: Args) => R
+  ? (...args: Args) => Awaitable<R>
   : never
 
 export type IpcBridgeApiInvoker<T> = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [K in keyof T]: T[K] extends (...args: any[]) => any
-    ? RemoveEventArg<T[K]>
+    ? IpcBridgeApiFunction<T[K]>
     : IpcBridgeApiInvoker<T[K]>
 }
-
-// export type IpcBridgeApiInvoker = IpcBridgeApiInvokerTypeGenerator<ApiHandler>
 
 type IpcBridgeApiReciver<T> = {
   [K in keyof T]: T[K] extends ApiHandler


### PR DESCRIPTION
The retrun value `ipcRenderer.on` is always promise type value. so
change Type defenition to adjust it.

Closes: #29
